### PR TITLE
made completions object-oriented

### DIFF
--- a/cody.el
+++ b/cody.el
@@ -87,16 +87,9 @@ use manual completion triggering with `cody-request-completion'."
    (-displayText :initarg :displayText
                 :initform nil
                 :type (or null string)
+                :accessor cody--get-display-text
                 :documentation "The updated text as the user types."))
   "Represents a single alternative/suggestion in a completion response.")
-
-(cl-defmethod cody-get-display-text ((item cody-completion-item))
-  "Get the display text for the completion item ITEM."
-  (oref item -displayText))
-
-(cl-defmethod cody-set-display-text ((item cody-completion-item) value)
-  "Set the display text for the completion item ITEM to VALUE."
-  (oset item -displayText value))
 
 (defclass cody-completion ()
   ((items :initarg :items
@@ -137,7 +130,7 @@ Ensure that the index is within the bounds of the items vector."
 (cl-defmethod cody-update-display-text ((cc cody-completion) text)
   "Update TEXT for the currently selected completion item in CC."
   (when-let ((current-item (cody-get-current-item cc)))
-    (cody-set-display-text current-item text)))
+    (setf (cody--get-display-text current-item) text)))
 
 (cl-defmethod cody-get-current-item ((cc cody-completion))
   "Retrieve the currently selected completion alternative from CC."


### PR DESCRIPTION
Our data structures for representing completions in elisp were becoming ad-hoc and difficult to understand and modify.

The completions UX is going to need many new features, so to keep things more readable I introduced three new classes.

The old code was just bolting a bunch of computed metadata onto the jsonrpc response object from the Agent, and now it all goes into named slots with readable accessors, for the most part.

I also fixed a bug where M-n and M-p were trying to cycle the completion everywhere in the buffer. Changed it so that it only cycles completions when you are at the beginning of an active, acceptable completion.

Telemetry
---------

The telemetry wasn't working before this change, and it's still not working now. However, teej informs me that it will largely move into the Agent next week, so I'm going to be removing all that code next week in any event.

Testing
-------
We still don't have tests yet. I want to start writing them, perhaps with ERT (built into Emacs). But I want to get this architectural change out quickly so I unblock anyone who wants to do nontrivial work on the file concurrently.