### PR TITLE
completion accepts now respect :range parameter

### DIFF
--- a/cody.el
+++ b/cody.el
@@ -12,7 +12,7 @@
 ;; Load this package and then add `(cody-start)' to your .emacs
 
 ;;; Code:
-;; (eval-when-compile (require 'cl-lib))
+(eval-when-compile (require 'cl-lib))
 (eval-when-compile (require 'eieio-base))
 (require 'auth-source)
 (require 'jsonrpc)
@@ -998,9 +998,8 @@ KIND specifies whether this was requested manually or automatically"
             (cody--log msg)
             (when manual (message msg))))
          ((zerop (length items))
-          (if (not manual)
-              (message "No completions returned")
-            (cody--flash-no-completions)))
+          (when manual
+            (message "No completions returned")))
          (t
           (let (cody--completion-timestamps) ; preserve the trigger time from request
             (ignore-errors (cody--discard-completion))

--- a/cody.el
+++ b/cody.el
@@ -190,12 +190,14 @@ You can call `cody-restart' to force it to re-check the version.")
 
 (defvar cody-mode-map
   (let ((map (make-sparse-keymap)))
-    (define-key map (kbd "C-c c") 'cody-request-completion) ; prolly a bad default?
+    (define-prefix-command 'cody-prefix-map)
+    (define-key map (kbd "C-c /") cody-prefix-map)
+    (define-key cody-prefix-map (kbd "c") 'cody-request-completion)
+    (define-key cody-prefix-map (kbd "x") 'cody-mode) ; toggle cody-mode off for buffer
     (define-key map (kbd "M-\\") 'cody-request-completion) ; for IntelliJ users
-    (define-key map (kbd "TAB") 'cody--tab-key)
+    (define-key map (kbd "TAB") 'cody--tab-key) ; accept completions
     (define-key map (kbd "C-g") 'cody--ctrl-g-key)
     (define-key map (kbd "ESC ESC ESC") 'cody--ctrl-g-key)
-    (define-key map (kbd "C-c x") 'cody-mode) ; toggle cody-mode off in this buffer
     (when cody-enable-completion-cycling
       (define-key map (kbd "M-n") 'cody-next-completion)
       (define-key map (kbd "M-p") 'cody-prev-completion))

--- a/cody.el
+++ b/cody.el
@@ -308,12 +308,12 @@ Each time we request a new completion, it gets discarded and replaced.")
                      :connection-type 'pipe
                      :stderr (get-buffer-create "*cody stderr*")
                      :noquery t)))
-    (cody--log "Sending 'initialize' request to agent")
+    ;;(cody--log "Sending 'initialize' request to agent")
     (jsonrpc-request cody--connection 'initialize
                      (list
                       :name "Emacs"
                       :version "0.1"
-                      :workspaceRootPath (cody--workspace-root)
+                      :workspaceRootUri (cody--workspace-root)
                       :extensionConfiguration (cody--extension-configuration)))
     (jsonrpc-notify cody--connection 'initialized nil))
   cody--connection)

--- a/cody.el
+++ b/cody.el
@@ -179,7 +179,7 @@ You can call `cody-restart' to force it to re-check the version.")
 
 (defun cody--agent-command ()
   "Command and arguments for running agent."
-  (list (or cody-node-path-override "node") cody--cody-agent ""))
+  (list (or cody-node-path-override "node") cody--cody-agent))
 
 (defvar cody--connection nil "Global jsonrpc connection to Agent.")
 (defvar cody--message-in-progress nil "Chat message accumulator.")


### PR DESCRIPTION
This solves part of the work to respect the range parameter, which enables the LLM to suggest a completion that replaces text before the cursor (point).

It now follows the range parameter when you accept a completion, deleting text preceding and following point if necessary, so that the accepted completion now nestles correctly within the surrounding code.

I still need to implement support for the range parameter when the completion is displayed. This is a bit more complex and will come in a follow-up commit.

This commit also includes some unrelated bug fixes.